### PR TITLE
Correct dir for docker-volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker-compose up database &
 
 ```bash
 docker network create gob-network
-docker volume create gob-volume --opt device=/tmp/gob --opt o=bind
+docker volume create gob-volume --opt device=/tmp --opt o=bind
 
 ```
 


### PR DESCRIPTION
In order to let local dockers be compatible with local
component executions let the volume point to /tmp