### PR TITLE
GOB-Import repository rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git clone git@github.com:Amsterdam/GOB-Documentation.git
 git clone git@github.com:Amsterdam/GOB-Workflow.git
 
 # GOB Import (the import of the GOB sources)
-git clone git@github.com:Amsterdam/GOB-Import-Client-Template.git
+git clone git@github.com:Amsterdam/GOB-Import.git
 
 # GOB Upload (the upload of imported data into GOB)
 git clone git@github.com:Amsterdam/GOB-Upload.git
@@ -30,9 +30,9 @@ git clone git@github.com:Amsterdam/GOB-API.git
 git clone git@github.com:Amsterdam/GOB-Export.git
 
 # GOB Management API (GOB management overview and control - API)
-git clone git@github.com:Amsterdam/GOB-API.git
+git clone git@github.com:Amsterdam/GOB-Management.git
 
-# GOB Management Frontenc (GOB management overview and control - frontend)
+# GOB Management Frontend (GOB management overview and control - frontend)
 git clone git@github.com:Amsterdam/GOB-Management-Frontend.git
 
 ```


### PR DESCRIPTION
The GOB-Import repository is now named GOB-Import

Also corrected some typos in the GOB-Management repository names