### PR TITLE
Provision .env dynamically

### DIFF
--- a/scripts/docker/startall.sh
+++ b/scripts/docker/startall.sh
@@ -65,13 +65,13 @@ init () {
     rm -rf /tmp/message_broker
     mkdir -m 777 /tmp/message_broker
 
-    echo "Init .env for import and export"
-    for REPO in Import Export
+    echo "Init .env for relevant projects"
+    for REPO_DIR in $(find ./ -name ".env.example" -maxdepth 2 -type f | xargs -I{} dirname {})
     do
-        cd "GOB-${REPO}"
+        cd $REPO_DIR
         if [ ! -f .env ]
         then
-            echo "Create empty credentials file (.env) for ${REPO}"
+            echo "Create empty credentials file (.env) for ${REPO_DIR}"
             cp .env.example .env
         fi
         cd -


### PR DESCRIPTION
**Problem**: When running `startall.sh` for the first time. GOB-Prepare has no `.env` file while the build phase of this project requires it.

**Fix**: after this change, `startall.sh` provisions the `.env` file for all projects that have a `.env.example` file.