### PR TITLE
fix: better API verification and circumvent racing condition

### DIFF
--- a/scripts/docker/DELETE.expect
+++ b/scripts/docker/DELETE.expect
@@ -19,70 +19,6 @@
                 "reference": {
                     "_links": {
                         "self": {
-                            "href": "/gob/test_catalogue/test_entity_ref/refid 2/"
-                        }
-                    },
-                    "bronwaarde": "refid 2",
-                    "_id": "refid 2"
-                }
-            },
-            "_links": {
-                "self": {
-                    "href": "/gob/test_catalogue/test_entity/id 2/"
-                }
-            },
-            "boolean": true,
-            "character": "e",
-            "date": "2020-10-22",
-            "datetime": "2019-01-22T14:35:30.025457",
-            "decimal": 3.4567,
-            "geometry": {
-                "coordinates": [
-                    1.0,
-                    2.0
-                ],
-                "type": "Point"
-            },
-            "integer": 10,
-            "json": {},
-            "point": {
-                "coordinates": [
-                    2.0,
-                    3.0
-                ],
-                "type": "Point"
-            },
-            "polygon": {
-                "coordinates": [
-                    [
-                        [
-                            51.0,
-                            3.0
-                        ],
-                        [
-                            51.3,
-                            3.61
-                        ],
-                        [
-                            51.3,
-                            3.0
-                        ],
-                        [
-                            51.0,
-                            3.0
-                        ]
-                    ]
-                ],
-                "type": "Polygon"
-            },
-            "string": "id 2"
-        },
-        {
-            "_embedded": {
-                "manyreference": null,
-                "reference": {
-                    "_links": {
-                        "self": {
                             "href": "/gob/test_catalogue/test_entity_ref/refid 3/"
                         }
                     },
@@ -140,6 +76,70 @@
                 "type": "Polygon"
             },
             "string": "id 3"
+        },
+        {
+            "_embedded": {
+                "manyreference": null,
+                "reference": {
+                    "_links": {
+                        "self": {
+                            "href": "/gob/test_catalogue/test_entity_ref/refid 2/"
+                        }
+                    },
+                    "bronwaarde": "refid 2",
+                    "_id": "refid 2"
+                }
+            },
+            "_links": {
+                "self": {
+                    "href": "/gob/test_catalogue/test_entity/id 2/"
+                }
+            },
+            "boolean": true,
+            "character": "e",
+            "date": "2020-10-22",
+            "datetime": "2019-01-22T14:35:30.025457",
+            "decimal": 3.4567,
+            "geometry": {
+                "coordinates": [
+                    1.0,
+                    2.0
+                ],
+                "type": "Point"
+            },
+            "integer": 10,
+            "json": {},
+            "point": {
+                "coordinates": [
+                    2.0,
+                    3.0
+                ],
+                "type": "Point"
+            },
+            "polygon": {
+                "coordinates": [
+                    [
+                        [
+                            51.0,
+                            3.0
+                        ],
+                        [
+                            51.3,
+                            3.61
+                        ],
+                        [
+                            51.3,
+                            3.0
+                        ],
+                        [
+                            51.0,
+                            3.0
+                        ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "string": "id 2"
         }
     ],
     "totalCount": 2

--- a/scripts/docker/bash.env
+++ b/scripts/docker/bash.env
@@ -1,0 +1,7 @@
+# Color constants
+NC=$'\e[0m'
+RED=$'\e[31m'
+GREEN=$'\e[32m'
+
+# Save docker output in $OUT
+OUT=/tmp/gob.out.txt

--- a/scripts/docker/client.py
+++ b/scripts/docker/client.py
@@ -1,0 +1,148 @@
+"""
+    Client.py
+
+    Usage:
+
+        $ cat expected.json | python client.py URI
+
+    Prints any differences between the JSON on specified
+    URI and the given JSON in stdin. No output == no differences.
+
+    Test (requires pytest):
+
+        $ python3 -m pytest client.py
+"""
+
+import difflib
+import functools
+import json
+import requests
+import sys
+import time
+import typing
+
+
+try:
+    import pytest
+except ImportError:
+    # no test
+    pytest = None
+
+
+def _diff(a: str, b: str) -> typing.Iterator[str]:
+    """ Returns a -/+ comparison of `a` and `b` """
+    differ = difflib.Differ()
+    return differ.compare(
+        *(
+            i.splitlines(keepends=True)
+            for i in (a, b)
+        )
+    )
+
+
+class MisMatch(AssertionError):
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    @staticmethod
+    def _render(d: dict) -> str:
+        return json.dumps(d, indent=2, sort_keys=True)
+
+    @property
+    def got(self) -> str:
+        return self._render(self.a)
+
+    @property
+    def expected(self) -> str:
+        return self._render(self.b)
+
+    def __str__(self) -> str:
+        result = _diff(self.got, self.expected)
+        return "AssertionError: diff:\n {}".format(
+                "".join(result)
+        )
+
+
+def check(actual_data, expected_data):
+    """ Checks URI for expected data,
+        raises Mismatch if there are differences.
+    """
+
+    # simple comparison now, could be more restrictive
+    if actual_data != expected_data:
+        raise MisMatch(actual_data, expected_data)
+
+
+def test_check():
+    # should work
+    check("a", "a")
+    with pytest.raises(MisMatch):
+        # a != b so should fail
+        check("b", "a")
+
+
+def retry(func: typing.Callable,
+          excs: typing.Tuple[Exception],
+          args=[], kwargs={}, attempts=5, sleep=1):
+    """ Retry callable `func` when any Exception is in `excs` is raised.
+        Pass `attempts` for the amount of retries, pass `sleep` in seconds
+        to enforce a back-off.
+    """
+    attempt = error = 0
+    while attempt < attempts:
+        attempt += 1
+        try:
+            return func(*args, **kwargs)
+        except excs as exc:
+            error = exc
+        time.sleep(sleep)
+    if error:
+        # We arrive here in case we got an expected error, raise it.
+        raise error
+
+
+def test_retry():
+    a = []
+
+    def _func(arg, a, kwarg):
+        a.append(1)
+        if len(a) > 3:
+            raise RuntimeError
+        assert (arg, kwarg) == ("foo", "bar")
+
+    retry_p = functools.partial(
+        retry, _func, excs=(AssertionError,), attempts=2, sleep=0.1
+    )
+
+    retry_p(args=["foo", a], kwargs={'kwarg': 'bar'})
+    assert len(a) == 1
+
+    with pytest.raises(AssertionError):
+        retry_p(args=["asd", a], kwargs={'kwarg': 'bar'})
+    assert len(a) == 3
+
+    with pytest.raises(RuntimeError):
+        retry_p(args=["asd", a], kwargs={'kwarg': 'bar'})
+    assert len(a) == 4
+
+
+def main(uri, expected_json):
+    """ application code """
+    expected_data = json.loads(expected_json)
+    retry(
+        lambda: check(requests.get(uri).json(), expected_data),
+        excs=(MisMatch,)
+    )
+
+
+if __name__ == "__main__":
+    """ interface code """
+    uri = sys.argv[1]
+    try:
+        main(
+            uri,
+            expected_json=sys.stdin.read()
+        )
+    except Exception as e:
+        print(e)

--- a/scripts/docker/e2e.sh
+++ b/scripts/docker/e2e.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e # stop on any error
+source bash.env
 
 # Start from directory where this script is located (GOB-Documentation/scripts)
 SCRIPTDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -23,46 +24,48 @@ else
 fi
 TESTS_DIR=data/test
 
-# Allow some time for processing the imports and exports
-SLEEP=15
-
-# Color constants
-NC=$'\e[0m'
-RED=$'\e[31m'
-GREEN=$'\e[32m'
-
 echo Starting tests
 N_ERRORS=0
 ERRORS=""
 
 API="http://localhost:8141/gob/test_catalogue/test_entity/"
-for TEST in ${TESTS}; do
 
+get_completed(){
+    expr $(grep -e "\(UPDATE]\s\+Update completed\|Import has failed\)" ${OUT}  | wc -l) + 1
+}
+
+for TEST in ${TESTS}; do
+    stime=$SECONDS
+    completed=$( get_completed || expr 0)
     echo Start import for test ${TEST}
     docker exec gobimport sh data/test/run_test.sh ${TEST}
     docker exec gobworkflow python -m gobworkflow.start import data/test/test.json
     # test is read from test.csv, copy test-csv to test.csv
     # Take some time to let GOB read the file
-    sleep ${SLEEP}
     echo Get API output for test ${TEST}
     EXPECT=${SCRIPTDIR}/${TEST}.expect
     if [ ! -f ${EXPECT} ]; then
         EXPECT="${SCRIPTDIR}/DELETE_ALL.expect"
     fi
-    EXPECT_JSON=$(cat $EXPECT             | json_pp | sed 's/\s\|,//g' | sort)
-    OUTPUT_JSON=$(curl ${API} 2>/dev/null | json_pp | sed 's/\s\|,//g' | sort)
+    while [[ $(get_completed) != $(expr ${completed} + 1) ]]; do
+        echo "Waiting for update complete..."
+        sleep 0.5
+    done
+    echo "Verifying update via API"
+    ERROR=$(cat $EXPECT | python3 client.py $API)
+
     # Uncomment next two line to redefine expectations
     # echo "${RED}Taking current output as expected output.${NC}"
-    # echo ${OUTPUT_JSON} > ${EXPECT}
-    if [ "${OUTPUT_JSON}" = "${EXPECT_JSON}" ]; then
-        echo "${GREEN}${TEST} OK ${NC}"
+    # echo ${OUTPUT} > ${EXPECT}
+    time_verb="(finished in $(($SECONDS - $stime)) seconds)"
+    if [ -z "$ERROR" ]; then
+        echo "${GREEN}${TEST} OK ${NC} ${time_verb}"
     else
-        echo "${RED}${TEST} FAILED ${NC}, output:"
-        curl ${API} | json_pp
+        echo "${RED}${TEST} FAILED ${NC} ${time_verb}, output:"
+        echo "${ERROR}"
         N_ERRORS=$(expr ${N_ERRORS} + 1)
         ERRORS="${ERRORS} ${TEST}"
     fi
-
 done
 
 echo "Test done, ${N_ERRORS} errors${RED}${ERRORS}${NC}"

--- a/scripts/docker/startall.sh
+++ b/scripts/docker/startall.sh
@@ -2,6 +2,7 @@
 
 set -u # crash on missing env
 set -e # stop on any error
+source bash.env
 
 # Start from directory where this script is located (GOB-Documentation/scripts)
 SCRIPTDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -122,7 +123,6 @@ start () {
 init 2> /dev/null || true
 
 # Save docker output in $OUT
-OUT=/tmp/gob.out.txt
 if [ -f "${OUT}" ]; then
     rm ${OUT}
 fi


### PR DESCRIPTION
*Problem*: `e2e.sh` is not working consistently (things might fail)

*Root cause*: Imports get denied if you send the too quick after each other since the import/prepare/upload workflow is still working on the first request. 

*Quick solution*: Make sure we only send updates after the previous one has been uploaded by checking the out log.

*Eventual solution*: Allow queuing of new imports so event sequence can be controlled

*Additional fixes*:
 * fixed DELETE.expect (order is different than actual result from API)
 * introduced `bash.env` for shared constants between `e2e.sh` and `startall.sh`
