### PR TITLE
Fix gob.sh ls command

### DIFF
--- a/scripts/docker/gob.sh
+++ b/scripts/docker/gob.sh
@@ -39,7 +39,7 @@ stop_dockers () {
 }
 
 show_docker () {
-    GREP=$(docker ps | grep $1) || true
+    GREP=$(docker ps | grep "$1$") || true
     if [ "$GREP" = "" ]; then
         echo " ${RED}DOWN${NC}"
     else


### PR DESCRIPTION
Fix grep command to list gobcontainers. Add end-of-line match, otherwise gobmanagement is listed as UP when gobmanagement-frontend is UP.